### PR TITLE
PR for #7: jax-maven-plugin cannot find extensions on unix

### DIFF
--- a/jax-maven-plugin-core/pom.xml
+++ b/jax-maven-plugin-core/pom.xml
@@ -22,6 +22,13 @@
             <scope>compile</scope>
         </dependency>
         
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.25</version>
+            <scope>runtime</scope>
+        </dependency>
+        
         <!-- test -->
         <dependency>
             <groupId>junit</groupId>

--- a/jax-maven-plugin-core/pom.xml
+++ b/jax-maven-plugin-core/pom.xml
@@ -11,6 +11,7 @@
 
     <properties>
         <jaxb.generated>${project.build.directory}/generated-sources/jaxb</jaxb.generated>
+        <version.slf4j>1.7.25</version.slf4j>
     </properties>
 
     <dependencies>
@@ -25,7 +26,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>${version.slf4j}</version>
+            <scope>runtime</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${version.slf4j}</version>
             <scope>runtime</scope>
         </dependency>
         


### PR DESCRIPTION
I've added runtime dependencies for the slf4j-api and its simple implementation. Depending on owners preferences, omit slf4j-simple (causes "Failed to load class org.slf4j.impl.StaticLoggerBinder" warnings), add slf4j-nop or do nothing here.