### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+arch:
+  - amd64
+  - ppc64le
 language: java
 jdk:
-  - oraclejdk8
-  - oraclejdk9
   - openjdk8
   - openjdk10
   - openjdk11


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/jax-maven-plugin/builds/191893530 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!